### PR TITLE
Update react-leaflet version to match toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^0.14.0",
     "react-bootstrap": "^0.27.3",
     "react-dom": "^0.14.0",
-    "react-leaflet": "^0.8.0",
+    "react-leaflet": "^0.9.0",
     "react-modal": "^0.6.1",
     "react-tabs": "^0.5.1"
   },


### PR DESCRIPTION
`toolkit` declares a `peerDependency` on `react-leaflet@^0.9.0`. This previously declared a dependency on `react-leaflet@^0.8.0`.
